### PR TITLE
Updated test settings to get DB credentials from environment

### DIFF
--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -28,8 +28,12 @@ MIDDLEWARE = [
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "NAME": "django_dicom",
+        "ENGINE": "django.db.backends.postgresql_psycopg2",
+        "NAME": os.getenv("DB_NAME", "django_dicom"),
+        "USER": os.getenv("DB_USER", "postgres"),
+        "PASSWORD": os.getenv("DB_PASSWORD", "password"),
+        "HOST": os.getenv("DB_HOST", "localhost"),
+        "PORT": os.getenv("DB_PORT", 5432),
     }
 }
 


### PR DESCRIPTION
Currently CircleCI fails beacuse it can't connect to the database. This is caused by a problem in the test_settings.py configuration.