### PR TITLE
PatientName bug fix

### DIFF
--- a/django_dicom/models/patient.py
+++ b/django_dicom/models/patient.py
@@ -1,5 +1,5 @@
 """
-Definition of the :class:`~django_dicom.models.patient.Patient` class.
+Definition of the :class:`Patient` class.
 
 """
 
@@ -15,14 +15,17 @@ class Patient(DicomEntity):
     """
     A model to represent a single instance of the Patient_ entity.
 
-    .. _Patient: http://dicom.nema.org/dicom/2013/output/chtml/part03/chapter_A.html
+    .. _Patient:
+       http://dicom.nema.org/dicom/2013/output/chtml/part03/chapter_A.html
 
     """
 
     #: `Patient ID
     #: <https://dicom.innolitics.com/ciods/mr-image/patient/00100020>`_
     #: value.
-    uid = models.CharField(max_length=64, unique=True, verbose_name="Patient UID")
+    uid = models.CharField(
+        max_length=64, unique=True, verbose_name="Patient UID"
+    )
 
     #: `Patient Birth Date
     #: <https://dicom.innolitics.com/ciods/mr-image/patient/00100030>`_
@@ -32,7 +35,9 @@ class Patient(DicomEntity):
     #: `Patient's Sex
     #: <https://dicom.innolitics.com/ciods/mr-image/patient/00100040>`_
     #: value.
-    sex = models.CharField(max_length=1, choices=Sex.choices(), blank=True, null=True)
+    sex = models.CharField(
+        max_length=1, choices=Sex.choices(), blank=True, null=True
+    )
 
     #: `Patient's Name
     #: <https://dicom.innolitics.com/ciods/mr-image/patient/00100010>`_
@@ -75,7 +80,10 @@ class Patient(DicomEntity):
     logger = logging.getLogger("data.dicom.patient")
 
     class Meta:
-        indexes = [models.Index(fields=["uid"]), models.Index(fields=["date_of_birth"])]
+        indexes = [
+            models.Index(fields=["uid"]),
+            models.Index(fields=["date_of_birth"]),
+        ]
 
     def __str__(self) -> str:
         """
@@ -101,6 +109,7 @@ class Patient(DicomEntity):
         str
             This instance's absolute URL path
         """
+
         return reverse("dicom:patient-detail", args=[str(self.id)])
 
     def get_full_name(self) -> str:
@@ -126,14 +135,14 @@ class Patient(DicomEntity):
             A DICOM image's :class:`~dicom_parser.header.Header` instance.
         """
 
-        patient_name = header.instance.get("PatientName")
+        patient_name = header.instance.get("PatientName", {})
         for part, value in patient_name.items():
             setattr(self, part, value)
 
     def update_fields_from_header(self, header, exclude: list = None) -> None:
         """
         Overrides
-        :meth:`django_dicom.model.dicom_entity.DicomEntity.update_fields_from_header`
+        :meth:`~django_dicom.model.dicom_entity.DicomEntity.update_fields_from_header`
         to handle setting the name parts.
 
         Parameters

--- a/tests/models/test_patient.py
+++ b/tests/models/test_patient.py
@@ -19,14 +19,20 @@ class PatientTestCase(TestCase):
     def setUpTestData(cls):
         """
         Creates instances to be used in the tests.
-        For more information see Django's :class:`~django.test.TestCase` documentation_.
+        For more information see Django's :class:`~django.test.TestCase`
+        documentation_.
 
-        .. _documentation: https://docs.djangoproject.com/en/2.2/topics/testing/tools/#testcase
+        .. _documentation:
+           https://docs.djangoproject.com/en/2.2/topics/testing/tools/#testcase
         """
 
-        TEST_SERIES_FIELDS["patient"] = Patient.objects.create(**TEST_PATIENT_FIELDS)
+        TEST_SERIES_FIELDS["patient"] = Patient.objects.create(
+            **TEST_PATIENT_FIELDS
+        )
         TEST_SERIES_FIELDS["study"] = Study.objects.create(**TEST_STUDY_FIELDS)
-        TEST_IMAGE_FIELDS["series"] = Series.objects.create(**TEST_SERIES_FIELDS)
+        TEST_IMAGE_FIELDS["series"] = Series.objects.create(
+            **TEST_SERIES_FIELDS
+        )
         Image.objects.create(**TEST_IMAGE_FIELDS)
 
     def setUp(self):
@@ -194,10 +200,11 @@ class PatientTestCase(TestCase):
 
     def test_update_patient_name(self):
         """
-        Tests patient name update according to the DICOM header `Patient's Name (PN)`_
-        data element fields.
+        Tests patient name update according to the DICOM header `Patient's
+        Name (PN)`_ data element fields.
 
-        .. _Patient's Name (PN): http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html
+        .. _Patient's Name (PN):
+           http://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html
 
         """
 
@@ -212,20 +219,23 @@ class PatientTestCase(TestCase):
 
     def test_update_fields_from_header(self):
         """
-        Tests that :meth:`~django_dicom.models.dicom_entity.DicomEntity.update_fields_from_header`
-        method returns the expected values. This test relies on the created instance's
-        fields containing the expected values beforehand.
+        Tests that
+        :meth:`~django_dicom.models.dicom_entity.DicomEntity.update_fields_from_header`
+        method returns the expected values. This test relies on the created
+        instance's fields containing the expected values beforehand.
 
         """
 
         header_fields = self.patient.get_header_fields()
         expected_values = {
-            field.name: getattr(self.patient, field.name) for field in header_fields
+            field.name: getattr(self.patient, field.name)
+            for field in header_fields
         }
         result = self.patient.update_fields_from_header(self.image.header)
         self.assertIsNone(result)
         values = {
-            field.name: getattr(self.patient, field.name) for field in header_fields
+            field.name: getattr(self.patient, field.name)
+            for field in header_fields
         }
         for key, value in values.items():
             try:
@@ -234,7 +244,9 @@ class PatientTestCase(TestCase):
                 if expected_values[key] is None:
                     self.assertEqual(value, "")
                 else:
-                    self.fail(f"expected {expected_values[key]} but got {value}")
+                    self.fail(
+                        f"expected {expected_values[key]} but got {value}"
+                    )
 
     def test_get_admin_link(self):
         """


### PR DESCRIPTION
Fixed exception raised for headers with no _PatientName_ - changed `get()` method's default to `{}` instead of `None`. Fixes #46.